### PR TITLE
Implemented moving the cursor up and down between member declarations.

### DIFF
--- a/HotCommands/CommandFilter.cs
+++ b/HotCommands/CommandFilter.cs
@@ -47,6 +47,10 @@ namespace HotCommands
                         return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations);
                     case Constants.DuplicateSelectionReverseCmdId:
                         return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations, true);
+                    case Constants.cmdidMoveCursorPrevMember:
+                        return MoveCursorToAdjacentMember.MoveToPreviousMember(textView);
+                    case Constants.cmdidMoveCursorNextMember:
+                        return MoveCursorToAdjacentMember.MoveToNextMember(textView);
                 }
             }
 
@@ -69,6 +73,8 @@ namespace HotCommands
                     case Constants.ExpandSelectionCmdId:
                     case Constants.DuplicateSelectionCmdId:
                     case Constants.DuplicateSelectionReverseCmdId:
+                    case Constants.cmdidMoveCursorPrevMember:
+                    case Constants.cmdidMoveCursorNextMember:
                         prgCmds[0].cmdf |= (uint)OLECMDF.OLECMDF_ENABLED;
                         return VSConstants.S_OK;
                 }

--- a/HotCommands/Commands/MoveCursorToAdjacentMember.cs
+++ b/HotCommands/Commands/MoveCursorToAdjacentMember.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.Text;
+using Microsoft.CodeAnalysis;
+using System.Linq;
+using System;
+
+namespace HotCommands
+{
+    class MoveCursorToAdjacentMember : Command<MoveCursorToAdjacentMember>
+    {
+        public static int MoveToNextMember(IWpfTextView textView)
+        {
+            return MoveToAdjacentMember(textView, up: false);
+        }
+        public static int MoveToPreviousMember(IWpfTextView textView)
+        {
+            return MoveToAdjacentMember(textView, up: true);
+        }
+
+        public static int MoveToAdjacentMember(IWpfTextView textView, bool up)
+        {
+            var syntaxRoot = textView.TextSnapshot.GetOpenDocumentInCurrentContextWithChanges().GetSyntaxRootAsync().Result;
+            var position = textView.Caret.Position.BufferPosition.Position;
+            var currMember = FindDeclarationAt(syntaxRoot, position);
+            if (currMember == null)
+            {
+                // We are not inside a definition
+                return VSConstants.S_OK;
+            }
+            SyntaxNode MoveToNode = null;
+            if (isContainer(currMember))
+            {
+                int posInContainer = getPosInContainer(currMember, position);
+                // The current member is a container. We need to deal with one of four (ish) possibilities:
+                // 1. We are at the top (or it is empty) and moving up
+                if (posInContainer <= 0 && up)
+                {
+                    MoveToNode = getPrevious(currMember);
+                }
+                // 2. We are at the bottom (or it is empty) and moving down
+                if (posInContainer >= 0 && !up)
+                {
+                    MoveToNode = getNext(currMember);
+                }
+                // 1. We are at the top and moving down
+                if (posInContainer == -1 && !up)
+                {
+                    // go to first child member declaration
+                    MoveToNode = currMember.DescendantNodes().OfType<MemberDeclarationSyntax>().FirstOrDefault();
+                }
+                // 2. WE are at the bottom and moving up
+                else if (posInContainer == 1 && up)
+                {
+                    // go to the last member
+                    MoveToNode = currMember.DescendantNodes().OfType<MemberDeclarationSyntax>().LastOrDefault();
+                }
+            }
+            else
+            {
+                if (up)
+                {
+                    MoveToNode = getPrevious(currMember);
+                }
+                else
+                {
+                    MoveToNode = getNext(currMember);
+                }
+            }
+            MoveCursor(textView, MoveToNode);
+            return VSConstants.S_OK;
+        }
+
+        public static MemberDeclarationSyntax getNext(SyntaxNode current)
+        {
+            // First, go to the parent
+            SyntaxNode Parent = current.Parent;
+            if (Parent == null)
+            {
+                // We have reached the root node, there can be no siblings, and therefore there is no next
+                return null;
+            }
+            bool foundSelf = false;
+            // Iterate through parent children
+            foreach (MemberDeclarationSyntax node in Parent.ChildNodes().OfType<MemberDeclarationSyntax>())
+            {
+                if (!foundSelf)
+                {
+                    // mark when we come accross our own node so that on the next one we can return it
+                    foundSelf = node.Equals(current);
+                }
+                else
+                {
+                    // return the next node after we find ourselves
+                    return node;
+                }
+            }
+            // If we get here, the current node was the last declaration in the parent
+            return getNext(Parent);
+        }
+
+        public static SyntaxNode getPrevious(SyntaxNode current)
+        {
+            SyntaxNode parent = current.Parent;
+            MemberDeclarationSyntax previous = null;
+            foreach (MemberDeclarationSyntax node in parent.ChildNodes().OfType<MemberDeclarationSyntax>())
+            {
+                if (node.Equals(current))
+                {
+                    if (previous == null)
+                    {
+                        return parent;
+                    }
+                    if (isContainer(previous))
+                    {
+                        return previous.DescendantNodesAndSelf().OfType<MemberDeclarationSyntax>().LastOrDefault();
+                    }
+                    return previous;
+                }
+                previous = node;
+            }
+            // this should never happen. By definition the node will be found within its own parent's children
+            return null;
+        }
+
+        public static void MoveCursor(IWpfTextView textView, SyntaxNode node)
+        {
+            if (node != null)
+            {
+                // move the cursor to the previous member
+                textView.Caret.MoveTo(new SnapshotPoint(textView.TextSnapshot, node.SpanStart));
+            }
+        }
+
+        private static bool isContainer(MemberDeclarationSyntax currMember)
+        {
+            return (currMember.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ClassDeclaration)
+                || currMember.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NamespaceDeclaration)
+                && currMember.DescendantNodes().OfType<MemberDeclarationSyntax>().Count() > 0);
+        }
+
+        /// <summary>
+        /// Determines if we are before or after the members of this container (or if there are none)
+        /// </summary>
+        /// <param name="currMember">The namespace or class SyntxNode</param>
+        /// <param name="position">The position in the text</param>
+        /// <returns>-1 if position is before all members, 0 if there are none, 1 if it is after all members</returns>
+        private static int getPosInContainer(MemberDeclarationSyntax currMember, int position)
+        {
+            var lastMember = currMember.DescendantNodes().OfType<MemberDeclarationSyntax>().LastOrDefault();
+            if (lastMember == null)
+            {
+                return 0;
+            }
+            else if (position > lastMember.FullSpan.End)
+            {
+                return 1;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        internal static MemberDeclarationSyntax FindDeclarationAt(SyntaxNode root, int position)
+        {
+            if (position > root.FullSpan.End || position < root.FullSpan.Start)
+            {
+                return null;
+            }
+            var token = root.FindToken(position, false);
+            var member = token.Parent.AncestorsAndSelf().OfType<MemberDeclarationSyntax>().FirstOrDefault();
+            return member;
+        }
+    }
+}

--- a/HotCommands/Constants.cs
+++ b/HotCommands/Constants.cs
@@ -10,5 +10,7 @@ namespace HotCommands
         public const uint ToggleCommentCmdId = 0x1021;
         public const uint ExpandSelectionCmdId = 0x1022;
         public const uint FormatCodeCmdId = 0x1027;
+        public const uint cmdidMoveCursorPrevMember = 0x1033;
+        public const uint cmdidMoveCursorNextMember = 0x1034;
     }
 }

--- a/HotCommands/HotCommands.csproj
+++ b/HotCommands/HotCommands.csproj
@@ -7,6 +7,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -26,7 +27,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HotCommands</RootNamespace>
     <AssemblyName>HotCommands</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -58,6 +59,7 @@
     <Compile Include="Commands\DuplicateSelection.cs" />
     <Compile Include="Commands\FormatCode.cs" />
     <Compile Include="Commands\ExpandSelection.cs" />
+    <Compile Include="Commands\MoveCursorToAdjacentMember.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="HotCommandsPackage.cs" />
     <Compile Include="KeyBindingUtil.cs" />
@@ -65,6 +67,7 @@
     <Compile Include="Commands\ToggleComment.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
@@ -84,6 +87,42 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.2\lib\net46\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.2\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures.Text, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.1.3.2\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Features, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Features.1.3.2\lib\net45\Microsoft.CodeAnalysis.Features.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.2\lib\net46\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
@@ -175,12 +214,102 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.1.0\lib\net46\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.2.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.0.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.0.1\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.FileSystem, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.0.1\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Reflection.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.3.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.2.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.0.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.0.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.1.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.0.1\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.0.1\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.4.0.1\lib\net46\System.Xml.XPath.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.0.1\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="VSPackage.resx">
@@ -198,6 +327,10 @@
   <ItemGroup>
     <Content Include="Resources\HotCommandsPackage.ico" />
     <Content Include="Resources\ToggleComment.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/HotCommands/HotCommandsPackage.vsct
+++ b/HotCommands/HotCommandsPackage.vsct
@@ -109,7 +109,25 @@
           <ButtonText>Format Code</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorPrevMember" priority="0x0200" type="Button">
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <Strings>
+        <ButtonText>Go To Previous Member</ButtonText>
+        </Strings>
+      </Button>
       
+
+      <Button guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorNextMember" priority="0x0200" type="Button">
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <Strings>
+        <ButtonText>Go To Next Member</ButtonText>
+        </Strings>
+      </Button>
+
+
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -139,6 +157,12 @@
     <CommandPlacement guid="guidHotCommandsPackageCmdSet" id="cmdidDuplicateSelectionReverse" priority="0x7515">
       <Parent guid="guidStdEditor" id="IDG_VS_EDITOR_ADVANCED_CMDS"/>
     </CommandPlacement>
+    <CommandPlacement guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorPrevMember" priority="0x7536">
+      <Parent guid="guidStdEditor" id="IDG_VS_EDITOR_ADVANCED_CMDS"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorNextMember" priority="0x7537">
+      <Parent guid="guidStdEditor" id="IDG_VS_EDITOR_ADVANCED_CMDS"/>
+    </CommandPlacement>
   </CommandPlacements>
 
   <VisibilityConstraints>
@@ -147,6 +171,8 @@
     <VisibilityItem guid="guidHotCommandsPackageCmdSet" id="cmdidFormatCode" context="GUID_TextEditorFactory"/>
     <VisibilityItem guid="guidHotCommandsPackageCmdSet" id="cmdidDuplicateSelection" context="GUID_TextEditorFactory"/>
     <VisibilityItem guid="guidHotCommandsPackageCmdSet" id="cmdidDuplicateSelectionReverse" context="GUID_TextEditorFactory"/>
+    <VisibilityItem guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorPrevMember" context="GUID_TextEditorFactory"/>
+    <VisibilityItem guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorNextMember" context="GUID_TextEditorFactory"/>
   </VisibilityConstraints>
   
   <KeyBindings>
@@ -155,6 +181,8 @@
     <KeyBinding guid="guidHotCommandsPackageCmdSet" id="cmdidFormatCode" editor="GUID_TextEditorFactory" mod1="Control Alt" key1="F"/>
     <KeyBinding guid="guidHotCommandsPackageCmdSet" id="cmdidDuplicateSelection" editor="GUID_TextEditorFactory" mod1="Control" key1="D"/>
     <KeyBinding guid="guidHotCommandsPackageCmdSet" id="cmdidDuplicateSelectionReverse" editor="GUID_TextEditorFactory" mod1="Control Shift" key1="D"/>
+    <KeyBinding guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorPrevMember" editor="GUID_TextEditorFactory" mod1="Control Alt" key1="VK_UP"/>
+    <KeyBinding guid="guidHotCommandsPackageCmdSet" id="cmdidMoveCursorNextMember" editor="GUID_TextEditorFactory" mod1="Control Alt" key1="VK_DOWN"/>
   </KeyBindings>
 
   <Symbols>
@@ -168,6 +196,8 @@
       <IDSymbol name="cmdidToggleComment" value="0x1021" />
       <IDSymbol name="cmdidExpandSelection" value="0x1022" />
       <IDSymbol name="cmdidFormatCode" value="0x1027" />
+      <IDSymbol name="cmdidMoveCursorPrevMember" value="0x1033" />
+      <IDSymbol name="cmdidMoveCursorNextMember" value="0x1034" />
     </GuidSymbol>
 
     <GuidSymbol name="guidImages1" value="{fcb5d1b2-db20-41ee-993f-9d92d1441d65}">

--- a/HotCommands/app.config
+++ b/HotCommands/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/HotCommands/packages.config
+++ b/HotCommands/packages.config
@@ -1,5 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="1.3.2" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="1.3.2" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Features" version="1.3.2" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net461" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Imaging" version="14.1.24720" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.1.24720" targetFramework="net452" />
@@ -19,4 +27,44 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.1.24720" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net452" />
   <package id="Microsoft.VSSDK.BuildTools" version="14.1.24720" targetFramework="net452" developmentDependency="true" />
+  <package id="System.AppContext" version="4.1.0" targetFramework="net461" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net461" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.2.0" targetFramework="net461" />
+  <package id="System.Console" version="4.0.0" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net461" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.0.0" targetFramework="net461" />
+  <package id="System.Diagnostics.StackTrace" version="4.0.1" targetFramework="net461" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net461" />
+  <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net461" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net461" />
+  <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net461" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net461" />
+  <package id="System.Reflection.Metadata" version="1.3.0" targetFramework="net461" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net461" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net461" />
+  <package id="System.Runtime.Handles" version="4.0.1" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net461" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net461" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net461" />
+  <package id="System.Text.Encoding.CodePages" version="4.0.1" targetFramework="net461" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net461" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net461" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Parallel" version="4.0.1" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net461" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net461" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net461" />
+  <package id="System.Xml.XmlDocument" version="4.0.1" targetFramework="net461" />
+  <package id="System.Xml.XPath" version="4.0.1" targetFramework="net461" />
+  <package id="System.Xml.XPath.XDocument" version="4.0.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This is the mostly complete implementation of Go To Next/Previous member. Using ctrl+alt+up/down you can move between members, classes, and namespaces in lexical ordering. 

There are a few remaining issues that need to be addressed:
If you are inside a method, it moves you up to the next member rather than to the top of the current one. 
If you are outside of all declarations, you cannot move to the first/last one. 
It erroneously lets you go to the top of the file. 
It places the cursor before annotations, not at the access modifier. 
It does not adjust scroll with the cursor. 