### PR TITLE
Fix Replacing Copy-Paste buffer on Duplicate

### DIFF
--- a/HotCommands/Commands/DuplicateSelection.cs
+++ b/HotCommands/Commands/DuplicateSelection.cs
@@ -49,9 +49,8 @@ namespace HotCommands.Commands
 
             if (isSingleLine)
             {
-                editorOperations.CopySelection();
-                editorOperations.MoveToNextCharacter(false);
-                editorOperations.Paste();
+                var text = editorOperations.SelectedText;
+                editorOperations.ReplaceSelection(string.Concat(text, text));
                 editorOperations.MoveToPreviousCharacter(false);
 
                 textView.Caret.MoveTo(new VirtualSnapshotPoint(trackingPoint.GetPoint(textView.TextSnapshot)).TranslateTo(textView.TextSnapshot));


### PR DESCRIPTION
Now if there is no selection, it not add to the copy-paste buffer anything on Duplicate Selection command.