### PR TITLE
Fixing null ref in InitializeFromConstructor

### DIFF
--- a/HotRefactorings/RefactoringProviders/InitializeFieldFromConstructor.cs
+++ b/HotRefactorings/RefactoringProviders/InitializeFieldFromConstructor.cs
@@ -67,11 +67,11 @@ namespace HotCommands
 
             var constructors = classDeclaration.DescendantNodes().OfType<ConstructorDeclarationSyntax>();
 
-            var relevantConstructors = constructors.Where(x =>
-                x.Body
-                .DescendantNodes()
-                .OfType<IdentifierNameSyntax>()
-                .All(identifier => identifier.Identifier.Text != fieldVariable.Identifier.Text));
+            var relevantConstructors = constructors
+                .Where(x => x.Body != null && x.Body
+                    .DescendantNodes()
+                    .OfType<IdentifierNameSyntax>()
+                    .All(identifier => identifier.Identifier.Text != fieldVariable.Identifier.Text));
 
             return relevantConstructors;
         }


### PR DESCRIPTION
Fixes NullReferenceException that can occur when the class contains a constructor with no body