### PR TITLE
Supresses error when expand selection can't work

### DIFF
--- a/HotCommands/Commands/ExpandSelection.cs
+++ b/HotCommands/Commands/ExpandSelection.cs
@@ -53,6 +53,10 @@ namespace HotCommands
         private async Task<int> HandleCommandShrinkTask(IWpfTextView textView)
         {
             var syntaxRoot = await textView.TextSnapshot.GetOpenDocumentInCurrentContextWithChanges().GetSyntaxRootAsync();
+            if (syntaxRoot == null)
+            {
+                return VSConstants.S_FALSE;
+            }
 
             var caretPos = textView.Caret.Position.BufferPosition;
 
@@ -91,6 +95,11 @@ namespace HotCommands
         private async Task<int> HandleCommandExpandTask(IWpfTextView textView)
         {
             var syntaxRoot = await textView.TextSnapshot.GetOpenDocumentInCurrentContextWithChanges().GetSyntaxRootAsync();
+            if (syntaxRoot == null)
+            {
+                return VSConstants.S_FALSE;
+            }
+
             var startPosition = textView.Selection.Start.Position;
             var endPosition = textView.Selection.End.Position;
             var length = endPosition.Position - startPosition.Position;


### PR DESCRIPTION
This PR suppresses error message mentioned in #58, until expand selection works in non-Roslyn project types