### PR TITLE
Make duplicate selection share code with duplicate lines

### DIFF
--- a/HotCommands/Commands/DuplicateSelection.cs
+++ b/HotCommands/Commands/DuplicateSelection.cs
@@ -35,9 +35,9 @@ namespace HotCommands.Commands
             _package = package;
         }
 
-        public static int HandleCommand_DuplicateLines(IWpfTextView textView, IClassifier classifier,
+        public static int HandleCommand(IWpfTextView textView, IClassifier classifier,
             IOleCommandTarget commandTarget, IEditorOperations editorOperations,
-            ITextBufferUndoManagerProvider undoManagerProvider, bool isCopyUp)
+            ITextBufferUndoManagerProvider undoManagerProvider, bool isDuplicateLines = false, bool isReversed = false)
         {
             // Use cases:
             // Single or Multiple carets
@@ -49,52 +49,64 @@ namespace HotCommands.Commands
 
             // Create a single transaction so the user can Undo all operations in one go.
             ITextBufferUndoManager undoManager = undoManagerProvider.GetTextBufferUndoManager(textView.TextBuffer);
-            ITextUndoTransaction transaction = undoManager.TextBufferUndoHistory.CreateTransaction("Duplicate Lines");
+            ITextUndoTransaction transaction = undoManager.TextBufferUndoHistory.CreateTransaction("Duplicate Selection");
 
             // This bool is to handle an annoying edge case where the selection would be expanded
             // by the inserted text because the insertion happens at the end of the selection.
             bool isEdgeCase_InsertExpandsSelection = false;
 
-            IMultiSelectionBroker broker = textView.GetMultiSelectionBroker();
-            IReadOnlyList<Selection> selections = broker.AllSelections;
-            Selection primarySelection = broker.PrimarySelection;
-            // Hack: Work from the last selection upward, to avoid changing buffer positions with mutli-caret
-            for (int i = selections.Count - 1; i >= 0; i--)
+            IMultiSelectionBroker selectionBroker = textView.GetMultiSelectionBroker();
+            IReadOnlyList<Selection> selections = selectionBroker.AllSelections;
+            Selection primarySelection = selectionBroker.PrimarySelection;
+            ITextSnapshot afterEditSnapshot;
+            using (ITextEdit edit = textView.TextBuffer.CreateEdit()) // Perform compound operation.
             {
-                Selection selection = selections[i];
-
-                SnapshotSpan selectionSpan = selection.Extent.SnapshotSpan;
-                SnapshotSpan selectedLines = GetContainingLines(selectionSpan);
-                string textToInsert = selectedLines.GetText();
-
-                bool isEndOfFile = selectedLines.End == textView.TextSnapshot.Length;
-
-                SnapshotPoint insertPos;
-                if (isCopyUp)
+                foreach (Selection selection in selections)
                 {
-                    insertPos = selectedLines.End;
+                    SnapshotSpan selectionSpan = selection.Extent.SnapshotSpan;
+                    bool isDuplicateLinesForThisSelection = isDuplicateLines || selectionSpan.Length == 0; // When selection length is zero we treat it as duplicate lines command (or should we not?).
+                    
+                    SnapshotSpan duplicationSpan;
+                    bool isMissingNewLine;
+                    if (isDuplicateLinesForThisSelection)
+                    {
+                        duplicationSpan = GetContainingLines(selectionSpan);
+                        isMissingNewLine = duplicationSpan.End == edit.Snapshot.Length;
+                    }
+                    else
+                    {
+                        duplicationSpan = selectionSpan;
+                        isMissingNewLine = false;
+                    }
 
-                    isEdgeCase_InsertExpandsSelection |= selectionSpan.End == insertPos;
+                    string textToInsert = duplicationSpan.GetText();
 
-                    // Case when there is no trailing new-line chars in the selected lines.
-                    if (isEndOfFile) textToInsert = Environment.NewLine + textToInsert;
+                    SnapshotPoint insertPos;
+                    if (isReversed)
+                    {
+                        insertPos = duplicationSpan.End;
+
+                        isEdgeCase_InsertExpandsSelection |= selectionSpan.End == insertPos;
+
+                        if (isMissingNewLine) textToInsert = Environment.NewLine + textToInsert;
+                    }
+                    else
+                    {
+                        insertPos = duplicationSpan.Start;
+
+                        if (isMissingNewLine) textToInsert = textToInsert + Environment.NewLine;
+                    }
+
+                    edit.Insert(insertPos, textToInsert);
                 }
-                else // (isCopyDown)
-                {
-                    insertPos = selectedLines.Start;
 
-                    // Case when there is no trailing new-line chars in the selected lines.
-                    if (isEndOfFile) textToInsert = textToInsert + Environment.NewLine;
-                }
-
-                textView.TextBuffer.Insert(insertPos, textToInsert);
+                afterEditSnapshot = edit.Apply();
             }
 
             if (isEdgeCase_InsertExpandsSelection)
             {
                 // Translate selections to newest snapshot with negative tracking mode for the
                 // end point so that they are not expanded due to the recent insertions.
-                var targetSnapshot = textView.TextSnapshot;
                 var newSelections = new Selection[selections.Count];
                 int primarySelectionIndex = 0;
                 for (int i = 0; i < newSelections.Length; i++)
@@ -102,7 +114,7 @@ namespace HotCommands.Commands
                     Selection selection = selections[i];
                     if (primarySelection.Equals(selection)) primarySelectionIndex = i;
                     newSelections[i] = TranslateTo(
-                        selection, targetSnapshot,
+                        selection, afterEditSnapshot,
                         GetPointTrackingMode(selection.InsertionPoint),
                         GetPointTrackingMode(selection.AnchorPoint),
                         GetPointTrackingMode(selection.ActivePoint)
@@ -115,7 +127,7 @@ namespace HotCommands.Commands
                     }
                 }
 
-                broker.SetSelectionRange(newSelections, newSelections[primarySelectionIndex]);
+                selectionBroker.SetSelectionRange(newSelections, newSelections[primarySelectionIndex]);
             }
 
             // Complete the transaction
@@ -164,152 +176,6 @@ namespace HotCommands.Commands
                     lastLine.EndIncludingLineBreak;
             }
             return new SnapshotSpan(linesStart, linesEnd);
-        }
-
-        // Helped by source of Microsoft.VisualStudio.Text.Editor.DragDrop.DropHandlerBase.cs in assembly Microsoft.VisualStudio.Text.UI.Wpf, Version=14.0.0.0
-        public static int HandleCommand(IWpfTextView textView, IClassifier classifier, IOleCommandTarget commandTarget, IEditorOperations editorOperations, bool shiftPressed = false)
-        {
-            //Guid cmdGroup = VSConstants.VSStd2K;
-            string selectedText = editorOperations.SelectedText;
-            ITrackingPoint trackingPoint = null;
-            if (selectedText.Length == 0)
-            {
-                // if nothing is selected, we can consider the current line as a selection
-                var virtualBufferPosition = editorOperations.TextView.Caret.Position.VirtualBufferPosition;
-                trackingPoint = textView.TextSnapshot.CreateTrackingPoint(virtualBufferPosition.Position, PointTrackingMode.Negative);
-
-                // Select all the text on the current line. Leaves caret at the start of the next line or end of line if last line.
-                editorOperations.SelectLine(textView.Caret.ContainingTextViewLine, false);
-                var text = editorOperations.SelectedText;
-                // Clear the selection so new inserts will not overwrite the selected line. Caret stays at start of next line.
-                editorOperations.ResetSelection();
-
-                // Hack for Last Line: If last line of file, introduce a new line character then delete it after duplicating the line.
-                var endOfFile = !EndsWithNewLine(text);
-                if (endOfFile)
-                {
-                    // We are on the last line. Will need to insert a new line. Will be removed later.
-                    editorOperations.InsertNewLine();
-                }
-
-                // Now we are at the beginning of the line we can insert the duplicate text.
-                editorOperations.InsertText(text);
-
-                // Clean up any newline character introduced by earlier hack
-                if (endOfFile)
-                {
-                    editorOperations.Delete();
-                }
-
-                // Return the cursor to its original position, then move it down one line (unless doing reverse)
-                textView.Caret.MoveTo(new VirtualSnapshotPoint(trackingPoint.GetPoint(textView.TextSnapshot)).TranslateTo(textView.TextSnapshot));
-                if (!shiftPressed) editorOperations.MoveLineDown(false);
-            }
-            else
-            {
-                var selection = textView.Selection;
-                var isReversed = selection.IsReversed;
-                var text = selectedText;
-                var textSnapshot = textView.TextSnapshot;
-                var list = new List<ITrackingSpan>();
-                //var shiftKeyPressed=textVie
-                foreach (SnapshotSpan snapshotSpan in selection.SelectedSpans)
-                {
-                    list.Add(textSnapshot.CreateTrackingSpan(snapshotSpan, SpanTrackingMode.EdgeExclusive));
-                }
-                if (!selection.IsEmpty)
-                {
-                    selection.Clear();
-                }
-
-
-                // Case where there is just one selection:
-                if (list.Count < 2)
-                {
-                    var offset = 0;
-                    var virtualBufferPosition = editorOperations.TextView.Caret.Position.VirtualBufferPosition;
-                    var point = editorOperations.TextView.Caret.Position.BufferPosition;
-                    virtualBufferPosition = isReversed && !shiftPressed ? new VirtualSnapshotPoint(point.Add(text.Length))
-                       : !isReversed && shiftPressed ? new VirtualSnapshotPoint(point.Add(-text.Length)) : virtualBufferPosition;
-
-                    trackingPoint = textSnapshot.CreateTrackingPoint(virtualBufferPosition.Position, PointTrackingMode.Negative);
-                    if (virtualBufferPosition.IsInVirtualSpace)
-                    {
-                        offset = editorOperations.GetWhitespaceForVirtualSpace(virtualBufferPosition).Length;
-                    }
-                    textView.Caret.MoveTo(virtualBufferPosition.TranslateTo(textView.TextSnapshot));
-                    editorOperations.InsertText(text);
-                    var insertionPoint = trackingPoint.GetPoint(textView.TextSnapshot);
-                    if (offset != 0)
-                    {
-                        insertionPoint = insertionPoint.Add(offset);
-                    }
-
-                    var virtualSnapshotPoint1 = new VirtualSnapshotPoint(insertionPoint);
-                    var virtualSnapshotPoint2 = new VirtualSnapshotPoint(insertionPoint.Add(text.Length));
-                    if (isReversed)
-                    {
-                        editorOperations.SelectAndMoveCaret(virtualSnapshotPoint2, virtualSnapshotPoint1, TextSelectionMode.Stream);
-                    }
-                    else
-                    {
-                        editorOperations.SelectAndMoveCaret(virtualSnapshotPoint1, virtualSnapshotPoint2, TextSelectionMode.Stream);
-                    }
-                }
-                // Handle Multi-selections:
-                else
-                {
-                    var trackingPointOffsetList = new List<Tuple<ITrackingPoint, int, int>>();
-                    //Insert Text!
-                    if (isReversed) list.Reverse();
-                    foreach (var trackingSpan in list)
-                    {
-                        SnapshotSpan span = trackingSpan.GetSpan(textSnapshot);
-                        text = trackingSpan.GetText(textSnapshot);
-                        int offset = 0;
-                        SnapshotPoint insertionPoint = !isReversed ? trackingSpan.GetEndPoint(span.Snapshot) : trackingSpan.GetStartPoint(span.Snapshot);
-                        var virtualBufferPosition = new VirtualSnapshotPoint(insertionPoint);
-                        virtualBufferPosition = isReversed && !shiftPressed ? new VirtualSnapshotPoint(insertionPoint.Add(text.Length))
-                           : !isReversed && shiftPressed ? new VirtualSnapshotPoint(insertionPoint.Add(-text.Length)) : virtualBufferPosition;
-
-
-                        trackingPoint = textSnapshot.CreateTrackingPoint(virtualBufferPosition.Position, PointTrackingMode.Negative);
-                        if (virtualBufferPosition.IsInVirtualSpace)
-                        {
-                            offset = editorOperations.GetWhitespaceForVirtualSpace(virtualBufferPosition).Length;
-                        }
-                        trackingPointOffsetList.Add(new Tuple<ITrackingPoint, int, int>(trackingPoint, offset, text.Length));
-                        textView.Caret.MoveTo(virtualBufferPosition.TranslateTo(textView.TextSnapshot));
-                        editorOperations.InsertText(text);
-                    }
-                    //Make Selections
-                    {
-                        var trackingPointOffset = trackingPointOffsetList.First();
-                        var insertionPoint = trackingPointOffset.Item1.GetPoint(textView.TextSnapshot);
-                        if (trackingPointOffset.Item2 != 0)
-                        {
-                            insertionPoint = insertionPoint.Add(trackingPointOffset.Item2);
-                        }
-                        var virtualSnapshotPoint1 = new VirtualSnapshotPoint(insertionPoint.Add(!isReversed ? 0 : trackingPointOffset.Item3));
-
-                        trackingPointOffset = trackingPointOffsetList.Last();
-                        insertionPoint = trackingPointOffset.Item1.GetPoint(textView.TextSnapshot);
-                        if (trackingPointOffset.Item2 != 0)
-                        {
-                            insertionPoint = insertionPoint.Add(trackingPointOffset.Item2);
-                        }
-                        var virtualSnapshotPoint2 = new VirtualSnapshotPoint(insertionPoint.Add(isReversed ? 0 : trackingPointOffset.Item3));
-                        editorOperations.SelectAndMoveCaret(virtualSnapshotPoint1, virtualSnapshotPoint2, TextSelectionMode.Box);
-                    }
-                }
-            }
-
-            return VSConstants.S_OK;
-        }
-        private static bool EndsWithNewLine(string text)
-        {
-            return text.Length > 0 &&
-                (text[text.Length - 1] == '\n' || text[text.Length - 1] == '\r');
         }
     }
 }

--- a/HotCommands/HotCommandsCommandFilter.cs
+++ b/HotCommands/HotCommandsCommandFilter.cs
@@ -55,14 +55,14 @@ namespace HotCommands
                             return ExpandSelection.Instance.HandleCommand(textView, false);
                         case Constants.FormatCodeCmdId:
                             return FormatCode.Instance.HandleCommand(textView, GetShellCommandDispatcher());
-                        case Constants.DuplicateLinesUpCmdId:
-                            return DuplicateSelection.HandleCommand_DuplicateLines(textView, classifier, GetShellCommandDispatcher(), editorOperations, undoManagerProvider, true);
-                        case Constants.DuplicateLinesDownCmdId:
-                            return DuplicateSelection.HandleCommand_DuplicateLines(textView, classifier, GetShellCommandDispatcher(), editorOperations, undoManagerProvider, false);
                         case Constants.DuplicateSelectionCmdId:
-                            return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations);
+                            return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations, undoManagerProvider, isDuplicateLines: false, isReversed: false);
                         case Constants.DuplicateSelectionReverseCmdId:
-                            return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations, true);
+                            return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations, undoManagerProvider, isDuplicateLines: false, isReversed: true);
+                        case Constants.DuplicateLinesDownCmdId:
+                            return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations, undoManagerProvider, isDuplicateLines: true, isReversed: false);
+                        case Constants.DuplicateLinesUpCmdId:
+                            return DuplicateSelection.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations, undoManagerProvider, isDuplicateLines: true, isReversed: true);
                         case Constants.JoinLinesCmdId:
                             return JoinLines.HandleCommand(textView, classifier, GetShellCommandDispatcher(), editorOperations);
                         case Constants.MoveMemberUpCmdId:


### PR DESCRIPTION
I managed to make duplicate selection use the same code as duplicate lines with minor tweaks. Should be much more robust now.

I also improved the code to use one ITextEdit for all modifications rather than one for each insertion, to avoid raising unnecessary events and not needing to go through selection buffer in reverse.