### PR TITLE
Add ARM64 installation target

### DIFF
--- a/HotCommands/source.extension.vsixmanifest
+++ b/HotCommands/source.extension.vsixmanifest
@@ -16,6 +16,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
I added an ARM64 installation target to the vsix manifest. I confirmed that it works on a Parallels Windows 11 VM.